### PR TITLE
changed depreciated File.exists to File.exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 script: 'bundle exec rake test'
 rvm:
-    - 1.9.2
+    - 2.1.2
 gemfile:
     - Gemfile
 branches:

--- a/lib/sras/asset_helper.rb
+++ b/lib/sras/asset_helper.rb
@@ -12,11 +12,11 @@ module SRAS
             asset_file = asset.base_dir + '/' + asset.sha256[0..2] + '/' + asset.sha256[3..5] + '/' + asset.sha256
             asset_data = ''
 
-            if File.exists?(asset_file + '.gz')
+            if File.exist?(asset_file + '.gz')
                 Zlib::GzipReader.open(asset_file + '.gz') do |file|
                     asset_data = file.read
                 end
-            elsif File.exists?(asset_file)
+            elsif File.exist?(asset_file)
                 File.open(asset_file) do |file|
                     asset_data = file.read
                 end
@@ -32,7 +32,7 @@ module SRAS
             # see if asset file with this hash already exists.  if it
             # does, then we don't need to overwrite it with identical
             # data...
-            if File.exists?(asset_file + '.gz') || File.exists?(asset_file)
+            if File.exist?(asset_file + '.gz') || File.exist?(asset_file)
                 return
             end 
 

--- a/lib/sras/config.rb
+++ b/lib/sras/config.rb
@@ -8,11 +8,11 @@ module SRAS
     module Config
         if ENV['SRAS_CONFIG_FILE']
             config_file = ENV['SRAS_CONFIG_FILE']
-        elsif File.exists?("../config/config.yml")
+        elsif File.exist?("../config/config.yml")
             config_file = "../config/config.yml"
-        elsif File.exists?(File.expand_path('~/.srasrc'))
+        elsif File.exist?(File.expand_path('~/.srasrc'))
             config_file = File.expand_path('~/.srasrc')
-        elsif File.exists?('/etc/sras/sras.conf')
+        elsif File.exist?('/etc/sras/sras.conf')
             config_file = '/etc/sras/sras.conf'
         else
             raise "Couldn't find SRAS config file"


### PR DESCRIPTION
Fixed a compatibility issue as File.exists has been depreciated in favor
of File.exist - this was causing install errors as several dependencies
now require Ruby >= 2.0